### PR TITLE
Bring in oorb updates

### DIFF
--- a/classes/Base_class.f90
+++ b/classes/Base_class.f90
@@ -1,6 +1,6 @@
 !====================================================================!
 !                                                                    !
-! Copyright 2002-2013,2014                                           !
+! Copyright 2002-2014,2015                                           !
 ! Mikael Granvik, Jenni Virtanen, Karri Muinonen, Teemu Laakso,      !
 ! Dagmara Oszkiewicz                                                 !
 !                                                                    !
@@ -35,7 +35,7 @@
 !! - angle = rad
 !!
 !! @author  MG, JV, TL
-!! @version 2014-08-22
+!! @version 2015-10-30
 !!
 MODULE Base_cl
 
@@ -97,9 +97,8 @@ MODULE Base_cl
   REAL(bp), PARAMETER :: sol      = 173.14463272_bp         !! Speed of light (AU/d).
   !REAL(bp), PARAMETER :: eps = 23.439280833_bp*rad_deg     !! Obliquity of ecliptic (J2000.0) 
   !!                                                           Gaia 2006 (84381.41100asec).
-  !REAL(bp), PARAMETER :: eps      = 23.439291111_bp*rad_deg !! Obliquity of ecliptic (J2000.0) Danby 1992.
-  REAL(bp), PARAMETER :: eps      = 23.439281111_bp*rad_deg !! Obliquity of ecliptic (J2000.0) JPL 2005.
-  !REAL(bp), PARAMETER :: eps      = 23.43929111111_bp*rad_deg !! Obliquity of ecliptic (J2000.0), old code
+  REAL(bp), PARAMETER :: eps = 23.43929111111111_bp*rad_deg !! Obliquity of ecliptic (J2000.0), IAU 1976
+  !!                                                           (used by Horizon, MPC, OrbFit)
   REAL(bp), PARAMETER :: r_earth  = 6378.140_bp/km_au       !! Earth equatorial radius (not mean!).
   REAL(bp), PARAMETER :: smamax   = 500.0_bp                !! Maximum for semimajor axis (AU).
   REAL(bp), PARAMETER :: rmoon    = 2.57e-3_bp              !! Earth-Moon mean distance (AU).

--- a/modules/integrators.f90
+++ b/modules/integrators.f90
@@ -1,6 +1,6 @@
 !====================================================================!
 !                                                                    !
-! Copyright 2002-2011,2012                                           !
+! Copyright 2002-2014,2015                                           !
 ! Mikael Granvik, Jenni Virtanen, Karri Muinonen, Teemu Laakso,      !
 ! Dagmara Oszkiewicz                                                 !
 !                                                                    !
@@ -26,7 +26,7 @@
 !! Contains integrators and force routines.
 !!
 !! @author  TL, MG, JV
-!! @version 2012-02-15
+!! @version 2015-10-28
 !!
 MODULE integrators
 
@@ -1964,7 +1964,7 @@ CONTAINS
     INTEGER :: NS
 
     ! Coordinates for the massive bodies.
-    REAL(prec), DIMENSION(:,:), POINTER :: wc
+    REAL(prec), DIMENSION(:,:), POINTER :: wc => NULL()
 
     ! Various distances.
     REAL(prec), DIMENSION(3,SIZE(perturbers)) :: drs 
@@ -2298,7 +2298,7 @@ CONTAINS
     INTEGER            :: NS
 
     ! Coordinates for the massive bodies.
-    REAL(prec), DIMENSION(:,:), POINTER :: wc_sun
+    REAL(prec), DIMENSION(:,:), POINTER :: wc_sun => NULL()
     REAL(prec), DIMENSION(:,:), ALLOCATABLE :: wc
     !REAL(prec), DIMENSION(10,6) :: wc
 

--- a/modules/linal.f90
+++ b/modules/linal.f90
@@ -1,6 +1,6 @@
 !====================================================================!
 !                                                                    !
-! Copyright 2002,2003,2004,2005,2006,2007,2008,2009,2010,2011        !
+! Copyright 2002-2014,2015                                           !
 ! Mikael Granvik, Jenni Virtanen, Karri Muinonen, Teemu Laakso,      !
 ! Dagmara Oszkiewicz                                                 !
 !                                                                    !
@@ -105,7 +105,7 @@
 !!
 !!
 !! @author  MG
-!! @version 2011-10-13
+!! @version 2015-10-28
 !!
 MODULE linal
 
@@ -1227,7 +1227,7 @@ CONTAINS
     REAL(rprec8), DIMENSION(SIZE(a,1)) :: dumc
     INTEGER, DIMENSION(2), TARGET :: irc
     INTEGER :: i,l,n
-    INTEGER, POINTER :: irow,icol
+    INTEGER, POINTER :: irow => NULL(), icol => NULL()
 
     n = SIZE(a,dim=1)
     irow => irc(1)

--- a/modules/planetary_data.f90
+++ b/modules/planetary_data.f90
@@ -49,7 +49,7 @@
 !!</pre>
 !!
 !! @author  MG, TL
-!! @version 2015-06-15
+!! @version 2015-10-28
 !!
 MODULE planetary_data
 
@@ -707,11 +707,12 @@ CONTAINS
 
     IMPLICIT NONE
     REAL(rprec16), INTENT(in)              :: mjd_tt
-    INTEGER, INTENT(in)               :: ntarget, ncenter
-    LOGICAL, INTENT(inout)            :: error
-    LOGICAL, OPTIONAL, INTENT(in)     :: km
+    INTEGER, INTENT(in)                    :: ntarget, ncenter
+    LOGICAL, INTENT(inout)                 :: error
+    LOGICAL, OPTIONAL, INTENT(in)          :: km
     REAL(rprec16), DIMENSION(:,:), POINTER :: JPL_ephemeris_r16
-    REAL(rprec8), DIMENSION(:,:), POINTER  :: tmp
+
+    REAL(rprec8), DIMENSION(:,:), POINTER  :: tmp => NULL()
     INTEGER :: err
 
     IF (PRESENT(km)) THEN
@@ -904,7 +905,8 @@ CONTAINS
     LOGICAL, INTENT(inout)                 :: error
     LOGICAL, OPTIONAL, INTENT(in)          :: km
     REAL(rprec16), DIMENSION(:,:), POINTER :: JPL_ephemeris_perturbers_r16
-    REAL(rprec8), DIMENSION(:,:), POINTER  :: tmp
+
+    REAL(rprec8), DIMENSION(:,:), POINTER  :: tmp => NULL()
     INTEGER :: err
 
     IF (PRESENT(km)) THEN


### PR DESCRIPTION
When comparing Oorb and JPL ephemerides, we discovered a discrepancy in how the position of the Earth/ obliquity of Earth's orbit was being handled. This updates oorb to use the same obliquity as JPL and MPC. 
